### PR TITLE
Updated mssql version in package.json to work when using Windows auth…

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dependencies": {
         "bluebird": "^3.5.4",
         "db-migrate-base": "^1.6.3",
-        "mssql": "6.0.0-beta.1"
+        "mssql": "9.1.1"
     },
     "devDependencies": {
         "db-meta": "^0.5.1",


### PR DESCRIPTION
I was receiving the following error "[ERROR] AssertionError [ERR_ASSERTION]: ifError got unwanted exception: Login failed. The login is from an untrusted domain and cannot be used with Windows authentication."

I have updated the package.json mssql version to 9.1.1 and it started working.